### PR TITLE
Made getBuildingNumFloors sql function explicitly look for public.bui…

### DIFF
--- a/InTheNou_Database_Scripts/InTheNou_Database_Schema.sql
+++ b/InTheNou_Database_Scripts/InTheNou_Database_Schema.sql
@@ -43,7 +43,7 @@ Create table Photos( photoID serial primary key,
 /* NOTE: Should some of the Building properties, like bCommonName or bType be NOT NULL?
    NOTE: Discussed with Diego, said bType should be NOT NULL, and bCommonName can be NULL.
    NOTE: Not all buildings have common names or codes. Insert them as empty strings*/
-Create table Buildings( bid serial primary key,
+Create table buildings( bid serial primary key,
                         bName text NOT NULL UNIQUE CHECK (bName <> ''),
                         bAbbrev Text NOT NULL,
                         numFloors int NOT NULL CHECK (numFloors > 0),
@@ -55,14 +55,14 @@ Create table Buildings( bid serial primary key,
    within the number of floors a building has.) */
 Create function getBuildingNumFloors (buildingid integer) RETURNS int as $$
 begin
- RETURN (SELECT numFloors from Buildings WHERE bid= buildingid); 
+ RETURN (SELECT numFloors FROM public.buildings WHERE bid= buildingid);
 end; $$
 language plpgsql;
 
 /* Create Rooms */
 /* NOTE: Should the coordinate fields be NOT NULL? 
    NOTE: Discussed with Diego; said coordinates should not be null.*/
-Create table Rooms( rid serial primary key,
+Create table rooms( rid serial primary key,
                     bid int references Buildings(bid),
                     rCode text NOT NULL UNIQUE CHECK (rCode <> ''),
                     rFloor int NOT NULL CHECK (rFloor >= 0 AND rFloor <= getBuildingNumFloors(bid)),


### PR DESCRIPTION
…ldings to fix database backup error.

-modified the sql function above, which looked for table "buildings", which was causing a massive error upon trying to restore from backup files.
-Since this was not looking explicitly for public.buildings, it caused the restore process to error out and prevent rooms from being restored, causing system instability.