### PR TITLE
Made _buildCoreEventResponse() get the full room by id, instead of Ti…

### DIFF
--- a/flask/app/handlers/EventHandler.py
+++ b/flask/app/handlers/EventHandler.py
@@ -28,7 +28,7 @@ def _buildCoreEventResponse(event_tuple):
     response = {}
     response['eid'] = event_tuple[0]
     response['ecreator'] = event_tuple[1]
-    response['room'] = RoomHandler().getTinyRoomByID(rid=event_tuple[2], no_json=True)
+    response['room'] = RoomHandler().safeGetRoomByID(rid=event_tuple[2])
     response['etitle'] = event_tuple[3]
     response['edescription'] = event_tuple[4]
     response['estart'] = str(event_tuple[5])


### PR DESCRIPTION
…ny room by id so that the App's smart notification may use the room coordinates from the followed upcoming events route.

-Changed the _buildCoreEventResponse() method to return the entire room information instead of the TinyRoom information.
-This was done because the App currently uses the results of the /following route to make smart notifications, and needs the room coordinates.
-This change affects the following methods and the routes they call:

getAllDeletedEventsSegmented
getAllEventsSegmented
getAllPastEventsSegmented
getEventsCreatedByUser
getDismissedEvents
getPastFollowedEventsSegmented
getUpcomingFollowedEventsSegmented
getUpcomingGeneralEventsSegmented
getUpcomingGeneralEventsByKeywordsSegmented
getUpcomingRecommendedEventsSegmented
getUpcomingRecommendedEventsByKeywordSegmented